### PR TITLE
VS2017 CE Support

### DIFF
--- a/calibrate.c
+++ b/calibrate.c
@@ -199,3 +199,4 @@ int main()
 	printf( "Returned\n" );
 }
 
+

--- a/include/libsurvive/survive.h
+++ b/include/libsurvive/survive.h
@@ -136,11 +136,13 @@ void survive_default_angle_process( SurviveObject * so, int sensor_id, int acode
 
 ////////////////////// Survive Drivers ////////////////////////////
 
+void   RegisterDriver( const char * name, void * data );
+
 #ifdef _WIN32
 #define REGISTER_LINKTIME( func )
 #else
 #define REGISTER_LINKTIME( func ) \
-	void __attribute__((constructor)) LTRegister##func() { RegisterDriver(#func, &func); }
+	void __attribute__((constructor)) REGISTER##func() { RegisterDriver(#func, &func); }
 #endif
 
 

--- a/include/libsurvive/survive.h
+++ b/include/libsurvive/survive.h
@@ -149,6 +149,7 @@ void survive_default_angle_process( SurviveObject * so, int sensor_id, int acode
 #define INITIALIZER2_(f,p) \
         __declspec(dllexport)  void f(void); \
         __declspec(allocate(".CRT$XCU")) void (*f##_)(void) = f; \
+		volatile static void * LTRegistrationPinnerFor##f = &##f; \
         __pragma(comment(linker,"/include:" p #f "_")) \
          void f(void)
 #ifdef _WIN64
@@ -176,6 +177,9 @@ void   RegisterDriver( const char * name, void * data );
 #define REGISTER_LINKTIME( func ) \
 	__declspec(dllexport) void LTRegister##func() { RegisterDriver( #func, &func ); } \
 	INITIALIZER(LTRegister##func) 
+	
+
+	//void __attribute__((constructor)) LTRegister##func() { RegisterDriver(#func, &func); }
 
 
 

--- a/include/libsurvive/survive.h
+++ b/include/libsurvive/survive.h
@@ -136,50 +136,12 @@ void survive_default_angle_process( SurviveObject * so, int sensor_id, int acode
 
 ////////////////////// Survive Drivers ////////////////////////////
 
-// The following macros were taken from StackOverflow here: 
-// http://stackoverflow.com/questions/1113409/attribute-constructor-equivalent-in-vc
-// The author, Joe Lowe explicitly released this code into the public domain as part of his post.
-#ifdef __cplusplus
-#define INITIALIZER(f) \
-        static void f(void); \
-        struct f##_t_ { f##_t_(void) { f(); } }; static f##_t_ f##_; \
-        static void f(void)
-#elif defined(_MSC_VER)
-#pragma section(".CRT$XCU",read)
-#define INITIALIZER2_(f,p) \
-        __declspec(dllexport)  void f(void); \
-        __declspec(allocate(".CRT$XCU")) void (*f##_)(void) = f; \
-		volatile static void * LTRegistrationPinnerFor##f = &##f; \
-        __pragma(comment(linker,"/include:" p #f "_")) \
-         void f(void)
-#ifdef _WIN64
-#define INITIALIZER(f) INITIALIZER2_(f,"")
+#ifdef _WIN32
+#define REGISTER_LINKTIME( func )
 #else
-#define INITIALIZER(f) INITIALIZER2_(f,"_")
-#endif
-#else
-#define INITIALIZER(f) \
-        static void f(void) __attribute__((constructor)); \
-        static void f(void)
-#endif
-// End macros from StackOverflow.
-
-//static void foo(void)
-//{
-//	int a=0;
-//}
-//
-//INITIALIZER(foo);
-
-
-void   RegisterDriver( const char * name, void * data );
-
 #define REGISTER_LINKTIME( func ) \
-	__declspec(dllexport) void LTRegister##func() { RegisterDriver( #func, &func ); } \
-	INITIALIZER(LTRegister##func) 
-	
-
-	//void __attribute__((constructor)) LTRegister##func() { RegisterDriver(#func, &func); }
+	void __attribute__((constructor)) LTRegister##func() { RegisterDriver(#func, &func); }
+#endif
 
 
 

--- a/include/libsurvive/survive.h
+++ b/include/libsurvive/survive.h
@@ -147,10 +147,10 @@ void survive_default_angle_process( SurviveObject * so, int sensor_id, int acode
 #elif defined(_MSC_VER)
 #pragma section(".CRT$XCU",read)
 #define INITIALIZER2_(f,p) \
-        static void f(void); \
+        __declspec(dllexport)  void f(void); \
         __declspec(allocate(".CRT$XCU")) void (*f##_)(void) = f; \
         __pragma(comment(linker,"/include:" p #f "_")) \
-        static void f(void)
+         void f(void)
 #ifdef _WIN64
 #define INITIALIZER(f) INITIALIZER2_(f,"")
 #else
@@ -163,11 +163,19 @@ void survive_default_angle_process( SurviveObject * so, int sensor_id, int acode
 #endif
 // End macros from StackOverflow.
 
+//static void foo(void)
+//{
+//	int a=0;
+//}
+//
+//INITIALIZER(foo);
+
 
 void   RegisterDriver( const char * name, void * data );
 
 #define REGISTER_LINKTIME( func ) \
-	INITIALIZER(LTRegister##func) { RegisterDriver( #func, &func ); }
+	__declspec(dllexport) void LTRegister##func() { RegisterDriver( #func, &func ); } \
+	INITIALIZER(LTRegister##func) 
 
 
 

--- a/redist/os_generic.h
+++ b/redist/os_generic.h
@@ -1,7 +1,7 @@
 #ifndef _OS_GENERIC_H
 #define _OS_GENERIC_H
 
-#if defined( WIN32 ) || defined (WINDOWS)
+#if defined( WIN32 ) || defined (WINDOWS) || defined( _WIN32)
 #define USE_WINDOWS
 #endif
 

--- a/redist/symbol_enumerator.c
+++ b/redist/symbol_enumerator.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include "symbol_enumerator.h"
 
-#if defined( WIN32 ) || defined( WINDOWS ) || defined( USE_WINDOWS )
+#if defined( WIN32 ) || defined( WINDOWS ) || defined( USE_WINDOWS ) || defined( _WIN32 )
 
 #include <windows.h>
 

--- a/src/survive.c
+++ b/src/survive.c
@@ -14,7 +14,8 @@
 static int did_runtime_symnum;
 int SymnumCheck( const char * path, const char * name, void * location, long size )
 {
-	if( strncmp( name, "REGISTER", 8 ) == 0 )
+	printf("%s\n", name);
+	if( strncmp( name, "LTRegister", 8 ) == 0 )
 	{
 		typedef void (*sf)();
 		sf fn = (sf)location;

--- a/src/survive.c
+++ b/src/survive.c
@@ -14,8 +14,7 @@
 static int did_runtime_symnum;
 int SymnumCheck( const char * path, const char * name, void * location, long size )
 {
-	printf("%s\n", name);
-	if( strncmp( name, "LTRegister", 8 ) == 0 )
+	if( strncmp( name, "REGISTER", 8 ) == 0 )
 	{
 		typedef void (*sf)();
 		sf fn = (sf)location;

--- a/src/survive.c
+++ b/src/survive.c
@@ -47,17 +47,17 @@ SurviveContext * survive_init( int headless )
 		did_runtime_symnum = 1;
 	}
 #endif
-//#ifdef MANUAL_REGISTRATION
-//	// note: this manual registration is currently only in use on builds using Visual Studio.
-//
-//#define MANUAL_DRIVER_REGISTRATION(func) int func( SurviveObject * so, PoserData * pd ); RegisterDriver( #func, &func);
-//
-//	MANUAL_DRIVER_REGISTRATION(PoserCharlesSlow)
-//	MANUAL_DRIVER_REGISTRATION(PoserDaveOrtho)
-//	MANUAL_DRIVER_REGISTRATION(PoserDummy)
-//	MANUAL_DRIVER_REGISTRATION(DriverRegHTCVive)
-//
-//#endif
+#ifdef MANUAL_REGISTRATION
+	// note: this manual registration is currently only in use on builds using Visual Studio.
+
+#define MANUAL_DRIVER_REGISTRATION(func) int func( SurviveObject * so, PoserData * pd ); RegisterDriver( #func, &func);
+
+	MANUAL_DRIVER_REGISTRATION(PoserCharlesSlow)
+	MANUAL_DRIVER_REGISTRATION(PoserDaveOrtho)
+	MANUAL_DRIVER_REGISTRATION(PoserDummy)
+	MANUAL_DRIVER_REGISTRATION(DriverRegHTCVive)
+
+#endif
 
 	int r = 0;
 	int i = 0;

--- a/src/survive.c
+++ b/src/survive.c
@@ -47,6 +47,17 @@ SurviveContext * survive_init( int headless )
 		did_runtime_symnum = 1;
 	}
 #endif
+//#ifdef MANUAL_REGISTRATION
+//	// note: this manual registration is currently only in use on builds using Visual Studio.
+//
+//#define MANUAL_DRIVER_REGISTRATION(func) int func( SurviveObject * so, PoserData * pd ); RegisterDriver( #func, &func);
+//
+//	MANUAL_DRIVER_REGISTRATION(PoserCharlesSlow)
+//	MANUAL_DRIVER_REGISTRATION(PoserDaveOrtho)
+//	MANUAL_DRIVER_REGISTRATION(PoserDummy)
+//	MANUAL_DRIVER_REGISTRATION(DriverRegHTCVive)
+//
+//#endif
 
 	int r = 0;
 	int i = 0;

--- a/src/survive_config.c
+++ b/src/survive_config.c
@@ -3,7 +3,7 @@
 #include <assert.h>
 #include "survive_config.h"
 #include <json_helpers.h>
-
+#include <malloc.h> //for alloca
 #include <errno.h>
 
 //#define MAX_CONFIG_ENTRIES 100
@@ -293,7 +293,8 @@ void pop_config_group() {
 
 int parse_floats(char* tag, char** values, uint16_t count) {
 	uint16_t i = 0;
-	FLT f[count];
+	FLT *f;
+	f = alloca(sizeof(FLT) * count);
 	char* end = NULL;
 	config_group* cg = cg_stack[cg_stack_head];
 
@@ -321,7 +322,8 @@ int parse_floats(char* tag, char** values, uint16_t count) {
 
 int parse_uint32(char* tag, char** values, uint16_t count) {
 	uint16_t i = 0;
-	uint32_t l[count];
+	FLT *l;
+	l = alloca(sizeof(FLT) * count);
 	char* end = NULL;
 	config_group* cg = cg_stack[cg_stack_head];
 

--- a/src/survive_vive.c
+++ b/src/survive_vive.c
@@ -17,11 +17,11 @@
 #include <errno.h>
 #include <string.h>
 #include <sys/stat.h>
-
+#include <malloc.h> // for alloca
 
 #ifdef HIDAPI
 #include <os_generic.h>
-#if defined(WINDOWS) || defined(WIN32)
+#if defined(WINDOWS) || defined(WIN32) || defined (_WIN32)
 #include <windows.h>
 #undef WCHAR_MAX
 #endif
@@ -125,14 +125,12 @@ void survive_data_cb( SurviveUSBInterface * si );
 void survive_usb_close( SurviveContext * t );
 int survive_usb_init( SurviveViveData * sv, SurviveObject * hmd, SurviveObject *wm0, SurviveObject * wm1, SurviveObject * tr0 );
 int survive_usb_poll( SurviveContext * ctx );
-int survive_get_config( char ** config, SurviveViveData * ctx, int devno, int interface, int send_extra_magic );
+int survive_get_config( char ** config, SurviveViveData * ctx, int devno, int iface, int send_extra_magic );
 int survive_vive_send_magic(struct SurviveContext * ctx, void * drv, int magic_code, void * data, int datalen );
 
 #ifdef HIDAPI
 void * HAPIReceiver( void * v )
 {
-	char buf[65];
-	int res;
 
 	SurviveUSBInterface * iface = v;
 	USBHANDLE * hp = &iface->uh;
@@ -239,13 +237,13 @@ static void debug_cb( struct SurviveUSBInterface * si )
 
 #ifdef HIDAPI
 
-static inline int update_feature_report(USBHANDLE dev, uint16_t interface, uint8_t * data, int datalen )
+static inline int update_feature_report(USBHANDLE dev, uint16_t iface, uint8_t * data, int datalen )
 {
 	int r = hid_send_feature_report( dev, data, datalen );
 //	printf( "HUR: (%p) %d (%d) [%d]\n", dev, r, datalen, data[0] );
 	return r;
 }
-static inline int getupdate_feature_report(USBHANDLE dev, uint16_t interface, uint8_t * data, int datalen ) 
+static inline int getupdate_feature_report(USBHANDLE dev, uint16_t iface, uint8_t * data, size_t datalen ) 
 {
 	int r = hid_get_feature_report( dev, data, datalen );
 //	printf( "HGR: (%p) %d (%d) (%d)\n", dev, r, datalen, data[0] );
@@ -277,13 +275,13 @@ static inline int getupdate_feature_report(libusb_device_handle* dev, uint16_t i
 
 #endif
 
-static inline int hid_get_feature_report_timeout(USBHANDLE device, uint16_t interface, unsigned char *buf, size_t len )
+static inline int hid_get_feature_report_timeout(USBHANDLE device, uint16_t iface, unsigned char *buf, size_t len )
 {
 	int ret;
 	uint8_t i = 0;
     for (i = 0; i < 50; i++)
 	{
-        ret = getupdate_feature_report(device, interface, buf, len);
+        ret = getupdate_feature_report(device, iface, buf, len);
 		if( ret != -9 && ( ret != -1 || errno != EPIPE ) ) return ret;
 		OGUSleep( 1000 );
 	}
@@ -604,7 +602,7 @@ int survive_vive_usb_poll( struct SurviveContext * ctx, void * v )
 int survive_get_config( char ** config, struct SurviveViveData * sv, int devno, int iface, int send_extra_magic )
 {
 	struct SurviveContext * ctx = sv->ctx;
-	int i, ret, count = 0, size = 0;
+	int ret, count = 0, size = 0;
 	uint8_t cfgbuff[64];
 	uint8_t compressed_data[8192];
 	uint8_t uncompressed_data[65536];
@@ -730,14 +728,13 @@ int survive_get_config( char ** config, struct SurviveViveData * sv, int devno, 
 
 static void handle_watchman( struct SurviveObject * w, uint8_t * readdata )
 {
-	int i;
 
 	uint8_t startread[29];
 	memcpy( startread, readdata, 29 );
 
 #if 0
 	printf( "DAT:     " );
-		for( i = 0; i < 29; i++ )
+		for(int i = 0; i < 29; i++ )
 		{
 			printf( "%02x ", readdata[i] );
 		}
@@ -823,7 +820,6 @@ static void handle_watchman( struct SurviveObject * w, uint8_t * readdata )
 
 	if( qty )
 	{
-		int j;
 		qty++;
 		readdata--;
 		*readdata = type; //Put 'type' back on stack.
@@ -846,7 +842,6 @@ static void handle_watchman( struct SurviveObject * w, uint8_t * readdata )
 		const int nrtime = sizeof(times)/sizeof(uint32_t);
 		int timecount = 0;
 		int leds;
-		int parameters;
 		int fault = 0;
 
 		///Handle uint32_tifying (making sure we keep it incrementing)
@@ -900,7 +895,8 @@ static void handle_watchman( struct SurviveObject * w, uint8_t * readdata )
 
 		//Second, go through all LEDs and extract the lightevent from them. 
 		{
-			uint8_t marked[nrtime];
+			uint8_t *marked;
+			marked = alloca(nrtime);
 			memset( marked, 0, sizeof( marked ) );
 			int i, parpl = 0;
 			timecount--;
@@ -1141,7 +1137,6 @@ static int ParsePoints( SurviveContext * ctx, SurviveObject * so, char * ct0conf
 	{
 		tk = &t[i+2+k*4];
 
-		FLT vals[3];
 		int m;
 		for( m = 0; m < 3; m++ )
 		{
@@ -1264,7 +1259,7 @@ int survive_vive_close( SurviveContext * ctx, void * driver )
 
 int DriverRegHTCVive( SurviveContext * ctx )
 {
-	int i, r;
+	int r;
 	SurviveObject * hmd = calloc( 1, sizeof( SurviveObject ) );
 	SurviveObject * wm0 = calloc( 1, sizeof( SurviveObject ) );
 	SurviveObject * wm1 = calloc( 1, sizeof( SurviveObject ) );
@@ -1273,7 +1268,9 @@ int DriverRegHTCVive( SurviveContext * ctx )
 
 	sv->ctx = ctx;
 	
-	#ifdef WINDOWS
+	#ifdef _WIN32
+		CreateDirectoryA("calinfo", NULL);
+	#elif defined WINDOWS
 		mkdir( "calinfo" );
 	#else
 		mkdir( "calinfo", 0755 );

--- a/winbuild/calibrate/calibrate.vcxproj
+++ b/winbuild/calibrate/calibrate.vcxproj
@@ -88,7 +88,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>RUNTIME_SYMNUM;HIDAPI;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>USE_DOUBLE;RUNTIME_SYMNUMX;HIDAPI;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\windows;..\..\include\libsurvive;..\..\redist;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
@@ -104,7 +104,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>RUNTIME_SYMNUM;HIDAPI;_CRT_SECURE_NO_WARNINGS;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>USE_DOUBLE;RUNTIME_SYMNUMX;HIDAPI;_CRT_SECURE_NO_WARNINGS;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\windows;..\..\include\libsurvive;..\..\redist;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
@@ -112,7 +112,8 @@
       <AdditionalLibraryDirectories>
       </AdditionalLibraryDirectories>
       <AdditionalDependencies>setupapi.lib;dbghelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <ForceSymbolReferences>LTRegisterDriverRegHTCVive;%(ForceSymbolReferences)</ForceSymbolReferences>
+      <ForceSymbolReferences>
+      </ForceSymbolReferences>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -123,7 +124,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>RUNTIME_SYMNUM;HIDAPI;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>USE_DOUBLE;RUNTIME_SYMNUMX;HIDAPI;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\windows;..\..\include\libsurvive;..\..\redist;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
@@ -143,7 +144,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>RUNTIME_SYMNUM;HIDAPI;_CRT_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>USE_DOUBLE;RUNTIME_SYMNUMX;HIDAPI;_CRT_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\windows;..\..\include\libsurvive;..\..\redist;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>

--- a/winbuild/calibrate/calibrate.vcxproj
+++ b/winbuild/calibrate/calibrate.vcxproj
@@ -88,11 +88,14 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>HIDAPI;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>RUNTIME_SYMNUM;HIDAPI;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\windows;..\..\include\libsurvive;..\..\redist;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>
+      </AdditionalLibraryDirectories>
+      <AdditionalDependencies>setupapi.lib;dbghelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -101,11 +104,15 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>HIDAPI;_CRT_SECURE_NO_WARNINGS;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>RUNTIME_SYMNUM;HIDAPI;_CRT_SECURE_NO_WARNINGS;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\windows;..\..\include\libsurvive;..\..\redist;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>
+      </AdditionalLibraryDirectories>
+      <AdditionalDependencies>setupapi.lib;dbghelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ForceSymbolReferences>LTRegisterDriverRegHTCVive;%(ForceSymbolReferences)</ForceSymbolReferences>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -116,13 +123,16 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>HIDAPI;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>RUNTIME_SYMNUM;HIDAPI;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\windows;..\..\include\libsurvive;..\..\redist;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>
+      </AdditionalLibraryDirectories>
+      <AdditionalDependencies>setupapi.lib;dbghelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -133,13 +143,16 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>HIDAPI;_CRT_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>RUNTIME_SYMNUM;HIDAPI;_CRT_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\windows;..\..\include\libsurvive;..\..\redist;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>
+      </AdditionalLibraryDirectories>
+      <AdditionalDependencies>setupapi.lib;dbghelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/winbuild/calibrate/calibrate.vcxproj
+++ b/winbuild/calibrate/calibrate.vcxproj
@@ -1,0 +1,159 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{A60984C4-0D12-423B-AED7-EBE4AD3F1C6B}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>calibrate</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>HIDAPI;_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\windows;..\..\include\libsurvive;..\..\redist;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>HIDAPI;_CRT_SECURE_NO_WARNINGS;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\windows;..\..\include\libsurvive;..\..\redist;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>HIDAPI;_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\windows;..\..\include\libsurvive;..\..\redist;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>HIDAPI;_CRT_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\windows;..\..\include\libsurvive;..\..\redist;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\calibrate.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\windows\hidapi.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\libsurvive\libsurvive.vcxproj">
+      <Project>{435cfd2c-8724-42ee-8fde-71ef7d2c6b2f}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/winbuild/calibrate/calibrate.vcxproj.filters
+++ b/winbuild/calibrate/calibrate.vcxproj.filters
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\calibrate.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\windows\hidapi.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/winbuild/libsurvive.sln
+++ b/winbuild/libsurvive.sln
@@ -1,0 +1,38 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.9
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "calibrate", "calibrate\calibrate.vcxproj", "{A60984C4-0D12-423B-AED7-EBE4AD3F1C6B}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libsurvive", "libsurvive\libsurvive.vcxproj", "{435CFD2C-8724-42EE-8FDE-71EF7D2C6B2F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A60984C4-0D12-423B-AED7-EBE4AD3F1C6B}.Debug|x64.ActiveCfg = Debug|x64
+		{A60984C4-0D12-423B-AED7-EBE4AD3F1C6B}.Debug|x64.Build.0 = Debug|x64
+		{A60984C4-0D12-423B-AED7-EBE4AD3F1C6B}.Debug|x86.ActiveCfg = Debug|Win32
+		{A60984C4-0D12-423B-AED7-EBE4AD3F1C6B}.Debug|x86.Build.0 = Debug|Win32
+		{A60984C4-0D12-423B-AED7-EBE4AD3F1C6B}.Release|x64.ActiveCfg = Release|x64
+		{A60984C4-0D12-423B-AED7-EBE4AD3F1C6B}.Release|x64.Build.0 = Release|x64
+		{A60984C4-0D12-423B-AED7-EBE4AD3F1C6B}.Release|x86.ActiveCfg = Release|Win32
+		{A60984C4-0D12-423B-AED7-EBE4AD3F1C6B}.Release|x86.Build.0 = Release|Win32
+		{435CFD2C-8724-42EE-8FDE-71EF7D2C6B2F}.Debug|x64.ActiveCfg = Debug|x64
+		{435CFD2C-8724-42EE-8FDE-71EF7D2C6B2F}.Debug|x64.Build.0 = Debug|x64
+		{435CFD2C-8724-42EE-8FDE-71EF7D2C6B2F}.Debug|x86.ActiveCfg = Debug|Win32
+		{435CFD2C-8724-42EE-8FDE-71EF7D2C6B2F}.Debug|x86.Build.0 = Debug|Win32
+		{435CFD2C-8724-42EE-8FDE-71EF7D2C6B2F}.Release|x64.ActiveCfg = Release|x64
+		{435CFD2C-8724-42EE-8FDE-71EF7D2C6B2F}.Release|x64.Build.0 = Release|x64
+		{435CFD2C-8724-42EE-8FDE-71EF7D2C6B2F}.Release|x86.ActiveCfg = Release|Win32
+		{435CFD2C-8724-42EE-8FDE-71EF7D2C6B2F}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/winbuild/libsurvive/ReadMe.txt
+++ b/winbuild/libsurvive/ReadMe.txt
@@ -1,0 +1,29 @@
+========================================================================
+    STATIC LIBRARY : libsurvive Project Overview
+========================================================================
+
+AppWizard has created this libsurvive library project for you.
+
+No source files were created as part of your project.
+
+
+libsurvive.vcxproj
+    This is the main project file for VC++ projects generated using an Application Wizard.
+    It contains information about the version of Visual C++ that generated the file, and
+    information about the platforms, configurations, and project features selected with the
+    Application Wizard.
+
+libsurvive.vcxproj.filters
+    This is the filters file for VC++ projects generated using an Application Wizard. 
+    It contains information about the association between the files in your project 
+    and the filters. This association is used in the IDE to show grouping of files with
+    similar extensions under a specific node (for e.g. ".cpp" files are associated with the
+    "Source Files" filter).
+
+/////////////////////////////////////////////////////////////////////////////
+Other notes:
+
+AppWizard uses "TODO:" comments to indicate parts of the source code you
+should add to or customize.
+
+/////////////////////////////////////////////////////////////////////////////

--- a/winbuild/libsurvive/libsurvive.vcxproj
+++ b/winbuild/libsurvive/libsurvive.vcxproj
@@ -77,7 +77,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>NOZLIB;_CRT_SECURE_NO_WARNINGS;HIDAPI;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>RUNTIME_SYMNUM;NOZLIB;_CRT_SECURE_NO_WARNINGS;HIDAPI;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\windows;..\..\include\libsurvive;..\..\redist;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
@@ -90,7 +90,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>NOZLIB;_CRT_SECURE_NO_WARNINGS;HIDAPI;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>RUNTIME_SYMNUM;NOZLIB;_CRT_SECURE_NO_WARNINGS;HIDAPI;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\windows;..\..\include\libsurvive;..\..\redist;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
@@ -105,7 +105,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>NOZLIB;_CRT_SECURE_NO_WARNINGS;HIDAPI;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>RUNTIME_SYMNUM;NOZLIB;_CRT_SECURE_NO_WARNINGS;HIDAPI;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\windows;..\..\include\libsurvive;..\..\redist;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
@@ -122,7 +122,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>NOZLIB;_CRT_SECURE_NO_WARNINGS;HIDAPI;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>RUNTIME_SYMNUM;NOZLIB;_CRT_SECURE_NO_WARNINGS;HIDAPI;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\windows;..\..\include\libsurvive;..\..\redist;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
@@ -141,6 +141,7 @@
     <ClCompile Include="..\..\redist\json_helpers.c" />
     <ClCompile Include="..\..\redist\os_generic.c" />
     <ClCompile Include="..\..\redist\puff.c" />
+    <ClCompile Include="..\..\redist\symbol_enumerator.c" />
     <ClCompile Include="..\..\redist\WinDriver.c" />
     <ClCompile Include="..\..\src\ootx_decoder.c" />
     <ClCompile Include="..\..\src\poser_charlesslow.c" />
@@ -154,6 +155,7 @@
     <ClCompile Include="..\..\src\survive_process.c" />
     <ClCompile Include="..\..\src\survive_usb.c" />
     <ClCompile Include="..\..\src\survive_vive.c" />
+    <ClCompile Include="..\..\windows\hid.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\include\libsurvive\poser.h" />
@@ -164,10 +166,12 @@
     <ClInclude Include="..\..\redist\jsmn.h" />
     <ClInclude Include="..\..\redist\json_helpers.h" />
     <ClInclude Include="..\..\redist\os_generic.h" />
+    <ClInclude Include="..\..\redist\symbol_enumerator.h" />
     <ClInclude Include="..\..\src\ootx_decoder.h" />
     <ClInclude Include="..\..\src\survive_cal.h" />
     <ClInclude Include="..\..\src\survive_config.h" />
     <ClInclude Include="..\..\src\survive_internal.h" />
+    <ClInclude Include="..\..\windows\hidapi.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/winbuild/libsurvive/libsurvive.vcxproj
+++ b/winbuild/libsurvive/libsurvive.vcxproj
@@ -77,7 +77,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>RUNTIME_SYMNUM;NOZLIB;_CRT_SECURE_NO_WARNINGS;HIDAPI;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>USE_DOUBLE;MANUAL_REGISTRATION;RUNTIME_SYMNUMX;NOZLIB;_CRT_SECURE_NO_WARNINGS;HIDAPI;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\windows;..\..\include\libsurvive;..\..\redist;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
@@ -90,7 +90,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>RUNTIME_SYMNUM;NOZLIB;_CRT_SECURE_NO_WARNINGS;HIDAPI;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>USE_DOUBLE;MANUAL_REGISTRATION;RUNTIME_SYMNUMX;NOZLIB;_CRT_SECURE_NO_WARNINGS;HIDAPI;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\windows;..\..\include\libsurvive;..\..\redist;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
@@ -105,7 +105,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>RUNTIME_SYMNUM;NOZLIB;_CRT_SECURE_NO_WARNINGS;HIDAPI;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>USE_DOUBLE;MANUAL_REGISTRATION;RUNTIME_SYMNUMX;NOZLIB;_CRT_SECURE_NO_WARNINGS;HIDAPI;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\windows;..\..\include\libsurvive;..\..\redist;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
@@ -122,7 +122,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>RUNTIME_SYMNUM;NOZLIB;_CRT_SECURE_NO_WARNINGS;HIDAPI;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>USE_DOUBLE;MANUAL_REGISTRATION;RUNTIME_SYMNUMX;NOZLIB;_CRT_SECURE_NO_WARNINGS;HIDAPI;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\windows;..\..\include\libsurvive;..\..\redist;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
@@ -139,6 +139,7 @@
     <ClCompile Include="..\..\redist\DrawFunctions.c" />
     <ClCompile Include="..\..\redist\jsmn.c" />
     <ClCompile Include="..\..\redist\json_helpers.c" />
+    <ClCompile Include="..\..\redist\linmath.c" />
     <ClCompile Include="..\..\redist\os_generic.c" />
     <ClCompile Include="..\..\redist\puff.c" />
     <ClCompile Include="..\..\redist\symbol_enumerator.c" />
@@ -165,6 +166,7 @@
     <ClInclude Include="..\..\redist\DrawFunctions.h" />
     <ClInclude Include="..\..\redist\jsmn.h" />
     <ClInclude Include="..\..\redist\json_helpers.h" />
+    <ClInclude Include="..\..\redist\linmath.h" />
     <ClInclude Include="..\..\redist\os_generic.h" />
     <ClInclude Include="..\..\redist\symbol_enumerator.h" />
     <ClInclude Include="..\..\src\ootx_decoder.h" />

--- a/winbuild/libsurvive/libsurvive.vcxproj
+++ b/winbuild/libsurvive/libsurvive.vcxproj
@@ -1,0 +1,175 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{435CFD2C-8724-42EE-8FDE-71EF7D2C6B2F}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>libsurvive</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>NOZLIB;_CRT_SECURE_NO_WARNINGS;HIDAPI;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\windows;..\..\include\libsurvive;..\..\redist;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>NOZLIB;_CRT_SECURE_NO_WARNINGS;HIDAPI;WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\windows;..\..\include\libsurvive;..\..\redist;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>NOZLIB;_CRT_SECURE_NO_WARNINGS;HIDAPI;WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\windows;..\..\include\libsurvive;..\..\redist;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>NOZLIB;_CRT_SECURE_NO_WARNINGS;HIDAPI;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\..\windows;..\..\include\libsurvive;..\..\redist;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <Text Include="ReadMe.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\redist\crc32.c" />
+    <ClCompile Include="..\..\redist\DrawFunctions.c" />
+    <ClCompile Include="..\..\redist\jsmn.c" />
+    <ClCompile Include="..\..\redist\json_helpers.c" />
+    <ClCompile Include="..\..\redist\os_generic.c" />
+    <ClCompile Include="..\..\redist\puff.c" />
+    <ClCompile Include="..\..\redist\WinDriver.c" />
+    <ClCompile Include="..\..\src\ootx_decoder.c" />
+    <ClCompile Include="..\..\src\poser_charlesslow.c" />
+    <ClCompile Include="..\..\src\poser_daveortho.c" />
+    <ClCompile Include="..\..\src\poser_dummy.c" />
+    <ClCompile Include="..\..\src\survive.c" />
+    <ClCompile Include="..\..\src\survive_cal.c" />
+    <ClCompile Include="..\..\src\survive_config.c" />
+    <ClCompile Include="..\..\src\survive_data.c" />
+    <ClCompile Include="..\..\src\survive_driverman.c" />
+    <ClCompile Include="..\..\src\survive_process.c" />
+    <ClCompile Include="..\..\src\survive_usb.c" />
+    <ClCompile Include="..\..\src\survive_vive.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\include\libsurvive\poser.h" />
+    <ClInclude Include="..\..\include\libsurvive\survive.h" />
+    <ClInclude Include="..\..\include\libsurvive\survive_types.h" />
+    <ClInclude Include="..\..\redist\crc32.h" />
+    <ClInclude Include="..\..\redist\DrawFunctions.h" />
+    <ClInclude Include="..\..\redist\jsmn.h" />
+    <ClInclude Include="..\..\redist\json_helpers.h" />
+    <ClInclude Include="..\..\redist\os_generic.h" />
+    <ClInclude Include="..\..\src\ootx_decoder.h" />
+    <ClInclude Include="..\..\src\survive_cal.h" />
+    <ClInclude Include="..\..\src\survive_config.h" />
+    <ClInclude Include="..\..\src\survive_internal.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/winbuild/libsurvive/libsurvive.vcxproj.filters
+++ b/winbuild/libsurvive/libsurvive.vcxproj.filters
@@ -75,6 +75,12 @@
     <ClCompile Include="..\..\redist\crc32.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\redist\symbol_enumerator.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\windows\hid.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\ootx_decoder.h">
@@ -111,6 +117,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\redist\crc32.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\redist\symbol_enumerator.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\windows\hidapi.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/winbuild/libsurvive/libsurvive.vcxproj.filters
+++ b/winbuild/libsurvive/libsurvive.vcxproj.filters
@@ -81,6 +81,9 @@
     <ClCompile Include="..\..\windows\hid.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\redist\linmath.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\ootx_decoder.h">
@@ -123,6 +126,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\windows\hidapi.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\redist\linmath.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/winbuild/libsurvive/libsurvive.vcxproj.filters
+++ b/winbuild/libsurvive/libsurvive.vcxproj.filters
@@ -1,0 +1,117 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="ReadMe.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\ootx_decoder.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\poser_charlesslow.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\poser_daveortho.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\poser_dummy.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\survive.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\survive_cal.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\survive_config.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\survive_data.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\survive_driverman.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\survive_process.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\survive_usb.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\survive_vive.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\redist\os_generic.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\redist\puff.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\redist\DrawFunctions.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\redist\WinDriver.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\redist\json_helpers.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\redist\jsmn.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\redist\crc32.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\ootx_decoder.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\survive_cal.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\survive_config.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\survive_internal.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\libsurvive\poser.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\libsurvive\survive.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\libsurvive\survive_types.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\redist\os_generic.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\redist\DrawFunctions.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\redist\json_helpers.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\redist\jsmn.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\redist\crc32.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Adds capability to build libsurvive using Visual Studio 2017 Community Edition
Currently only building libsurvive and calibrate.  Will add more if this is approved.

This builds libsurvive as a static library.  If anybody wants to add a build target to also build a dll, I'm A-OK with that.

After way too much beating my head against the wall, reading that it's not possible, and trying a bunch of possible work-arounds, I gave up on trying to get the link-time registration of plugins to work.  Instead, I added a few lines to survive_init to register them, #ifdef'd for _WIN32.  