### PR TITLE
Initial C++ client support

### DIFF
--- a/include/libsurvive/poser.h
+++ b/include/libsurvive/poser.h
@@ -3,6 +3,11 @@
 
 #include "survive_types.h"
 
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef enum PoserType_t
 {
 	POSERDATA_NONE = 0,
@@ -54,5 +59,9 @@ typedef struct
 //When you write your posers, use the following definition, and register with REGISTER_LINKTIME.
 typedef int (*PoserCB)( SurviveObject * so, PoserData * pd );
 
+
+#ifdef __cplusplus
+};
+#endif
 
 #endif

--- a/include/libsurvive/survive.h
+++ b/include/libsurvive/survive.h
@@ -5,6 +5,10 @@
 #include "survive_types.h"
 #include "poser.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 //DANGER: This structure may be redefined.  Note that it is logically split into 64-bit chunks
 //for optimization on 32- and 64-bit systems.
 
@@ -116,7 +120,7 @@ void survive_install_imu_fn( SurviveContext * ctx,  imu_process_func fbp );
 void survive_install_angle_fn( SurviveContext * ctx,  angle_process_func fbp );
 
 void survive_close( SurviveContext * ctx );
-int survive_poll();
+int survive_poll( SurviveContext * ctx );
 
 SurviveObject * survive_get_so_by_name( SurviveContext * ctx, const char * name );
 
@@ -127,6 +131,9 @@ int survive_send_magic( SurviveContext * ctx, int magic_code, void * data, int d
 
 //Install the calibrator.
 void survive_cal_install( SurviveContext * ctx );  //XXX This will be removed if not already done so.
+
+// Read back a human-readable string description of the calibration status
+int survive_cal_get_status( struct SurviveContext * ctx, char * description, int description_length );
 
 //Call these from your callback if overridden.  
 //Accept higher-level data.
@@ -173,6 +180,10 @@ void handle_lightcap( SurviveObject * so, LightcapElement * le );
 #define SV_INFO( ... ) { char stbuff[1024]; sprintf( stbuff, __VA_ARGS__ ); ctx->notefunction( ctx, stbuff ); }
 #define SV_ERROR( ... ) { char stbuff[1024]; sprintf( stbuff, __VA_ARGS__ ); ctx->faultfunction( ctx, stbuff ); }
 #define SV_KILL()		exit(0)  //XXX This should likely be re-defined.
+
+#ifdef __cplusplus
+};
+#endif
 
 #endif
 

--- a/include/libsurvive/survive_types.h
+++ b/include/libsurvive/survive_types.h
@@ -1,6 +1,11 @@
 #ifndef _SURVIVE_TYPES_H
 #define _SURVIVE_TYPES_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 #ifndef FLT
 #ifdef USE_DOUBLE
 #define FLT double
@@ -39,6 +44,9 @@ typedef int (*DeviceDriver)( SurviveContext * ctx );
 typedef int (*DeviceDriverCb)( struct SurviveContext * ctx, void * driver );
 typedef int (*DeviceDriverMagicCb)( struct SurviveContext * ctx, void * driver, int magic_code, void * data, int datalen );
 
+#ifdef __cplusplus
+};
+#endif
 
 #endif
 

--- a/redist/os_generic.c
+++ b/redist/os_generic.c
@@ -151,8 +151,9 @@ void OGDeleteSema( og_sema_t os )
 
 #else
 
-#define _GNU_SOURCE
-
+#ifndef _GNU_SOURCE
+#  define _GNU_SOURCE
+#endif
 
 #include <sys/stat.h>
 #include <stdlib.h>
@@ -198,7 +199,7 @@ double OGGetFileTime( const char * file )
 
 og_thread_t OGCreateThread( void * (routine)( void * ), void * parameter )
 {
-	pthread_t * ret = malloc( sizeof( pthread_t ) );
+	pthread_t * ret = (pthread_t *)malloc( sizeof( pthread_t ) );
 	int r = pthread_create( ret, 0, routine, parameter );
 	if( r )
 	{
@@ -277,7 +278,7 @@ void OGDeleteMutex( og_mutex_t om )
 
 og_sema_t OGCreateSema()
 {
-	sem_t * sem = malloc( sizeof( sem_t ) );
+	sem_t * sem = (sem_t *)malloc( sizeof( sem_t ) );
 	sem_init( sem, 0, 0 );
 	return (og_sema_t)sem;
 }
@@ -285,24 +286,24 @@ og_sema_t OGCreateSema()
 int OGGetSema( og_sema_t os )
 {
 	int valp;
-	sem_getvalue( os, &valp );
+	sem_getvalue( (sem_t *)os, &valp );
 	return valp;
 }
 
 
 void OGLockSema( og_sema_t os )
 {
-	sem_wait( os );
+	sem_wait( (sem_t *)os );
 }
 
 void OGUnlockSema( og_sema_t os )
 {
-	sem_post( os );
+	sem_post( (sem_t *)os );
 }
 
 void OGDeleteSema( og_sema_t os )
 {
-	sem_destroy( os );
+	sem_destroy( (sem_t *)os );
 	free(os);
 }
 

--- a/src/survive_data.c
+++ b/src/survive_data.c
@@ -4,6 +4,7 @@
 #include "survive_internal.h"
 #include <stdint.h>
 #include <string.h>
+#include <math.h> /* for sqrt */
 
 #define USE_TURVEYBIGUATOR
 


### PR DESCRIPTION
Minor changes to allow libsurvive to be called from C++: added extern "C" declarations in the externally visible headers, and cleaned up the header function prototypes.   This doesn't hurt plain C at all, and fixes several warnings.