### PR TITLE
Reduce Poser Calls

### DIFF
--- a/src/poser_turveytori.c
+++ b/src/poser_turveytori.c
@@ -1520,7 +1520,7 @@ int PoserTurveyTori( SurviveObject * so, PoserData * poserData )
 				counter++;
 
 				// let's just do this occasionally for now...
-				//if (counter % 1 == 0)
+				if (counter % 4 == 0)
 					QuickPose(so, 0);
 			}
 			// axis changed, time to increment the circular buffer index.


### PR DESCRIPTION
I've been seeing starvation that manifests itself as weird light data coming into the disambiguator.  A major cause ended up being starvation.  This change will cut the frequency of poser calls by by 75%