### PR TITLE
Add support for using only 1 lighthouse

### DIFF
--- a/calibrate.c
+++ b/calibrate.c
@@ -14,6 +14,7 @@
 
 struct SurviveContext * ctx;
 int  quit = 0;
+static LighthouseCount = 0;
 
 void HandleKey( int keycode, int bDown )
 {
@@ -342,6 +343,7 @@ int SurviveThreadLoaded=0;
 void * SurviveThread(void *jnk)
 {
 	ctx = survive_init( 0 );
+
 
 	uint8_t i =0;
 	for (i=0;i<32;++i) {

--- a/include/libsurvive/survive.h
+++ b/include/libsurvive/survive.h
@@ -102,6 +102,7 @@ struct SurviveContext
 	struct config_group* lh_config; //lighthouse configs
 
 	//Calibration data:
+	int activeLighthouses;
 	BaseStationData bsd[NUM_LIGHTHOUSES];
 	SurviveCalData * calptr; //If and only if the calibration subsystem is attached.
 

--- a/src/survive.c
+++ b/src/survive.c
@@ -75,6 +75,8 @@ SurviveContext * survive_init( int headless )
 
 	config_read(ctx, "config.json");
 
+	ctx->activeLighthouses = config_read_uint32(ctx->global_config_values, "LighthouseCount", 2);
+
 	ctx->faultfunction = survivefault;
 	ctx->notefunction = survivenote;
 

--- a/src/survive_cal.c
+++ b/src/survive_cal.c
@@ -218,7 +218,7 @@ void survive_cal_light( struct SurviveObject * so, int sensor_id, int acode, int
 			int i;
 			for( i = 0; i < NUM_LIGHTHOUSES; i++ )
 				if( ctx->bsd[i].OOTXSet == 0 ) break;
-			if( i == NUM_LIGHTHOUSES ) cd->stage = 2;  //TODO: Make this configuratble to allow single lighthouse.
+			if( i == ctx->activeLighthouses ) cd->stage = 2;  //TODO: Make this configuratble to allow single lighthouse.
 		}
 		break;
 	case 3: //Look for light sync lengths.
@@ -309,7 +309,7 @@ void survive_cal_angle( struct SurviveObject * so, int sensor_id, int acode, uin
 			cd->found_common = 1;
 			for( i = 0; i < cd->numPoseObjects; i++ )
 			//for( i = 0; i < MAX_SENSORS_TO_CAL/SENSORS_PER_OBJECT; i++ )
-			for( j = 0; j < NUM_LIGHTHOUSES; j++ )
+			for( j = 0; j < ctx->activeLighthouses; j++ )
 			{
 				int sensors_visible = 0;
 				for( k = 0; k < SENSORS_PER_OBJECT; k++ )


### PR DESCRIPTION
Change adds a config option for the number of "active" lighthouses,
which can be 1.  Calibrate will run with a single lighthouse
if the new config option LighthouseCount is set to 1.