### PR TITLE
Added a check at init that makes sure the user agrees with what FLT is

### DIFF
--- a/include/libsurvive/survive.h
+++ b/include/libsurvive/survive.h
@@ -156,7 +156,15 @@ struct SurviveContext
 
 };
 
-SurviveContext * survive_init( int headless );
+SurviveContext * survive_init_internal( int headless );
+
+// Baked in size of FLT to verify users of the library have the correct setting. 
+void survive_verify_FLT_size(uint32_t user_size);
+  
+static inline SurviveContext * survive_init( int headless ) {
+  survive_verify_FLT_size(sizeof(FLT));
+  return survive_init_internal( headless );
+}
 
 //For any of these, you may pass in 0 for the function pointer to use default behavior.
 //In general unless you are doing wacky things like recording or playing back data, you won't need to use this.

--- a/src/survive.c
+++ b/src/survive.c
@@ -94,7 +94,14 @@ static void *button_servicer(void * context)
 	return NULL;
 }
 
-SurviveContext * survive_init( int headless )
+void survive_verify_FLT_size(uint32_t user_size) {
+  if(sizeof(FLT) != user_size) {
+    fprintf(stderr, "FLT type incompatible; the shared library has FLT size %lu vs user program %u\n", sizeof(FLT), user_size);
+    exit(-1);
+  }
+}
+
+SurviveContext * survive_init_internal( int headless )
 {
 #ifdef RUNTIME_SYMNUM
 	if( !did_runtime_symnum )

--- a/src/survive.c
+++ b/src/survive.c
@@ -96,7 +96,9 @@ static void *button_servicer(void * context)
 
 void survive_verify_FLT_size(uint32_t user_size) {
   if(sizeof(FLT) != user_size) {
-    fprintf(stderr, "FLT type incompatible; the shared library has FLT size %lu vs user program %u\n", sizeof(FLT), user_size);
+    fprintf(stderr, "FLT type incompatible; the shared library libsurvive has FLT size %lu vs user program %u\n", sizeof(FLT), user_size);
+    fprintf(stderr, "Add '#define FLT %s' before including survive.h or recompile the shared library with the appropriate flag. \n",
+	    sizeof(FLT) == sizeof(double) ? "double" : "float");
     exit(-1);
   }
 }


### PR DESCRIPTION
Looked into changing the default but might have knock-on effects with either people already set up and running, and also with the linmath.h file. 

This seems like a good last resort solution. It exits at runtime when you call survive_init if the user compiled with inconsistent flags. 

An easy way to test this currently is to make, rm test, edit the Makefile to remove -DUSE_DOUBLE and make test. When you run test now, it'll exit immediately with an error message whereas before it'd return nonsensical values. 