### PR TITLE
remove forced-source license notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,16 +1,10 @@
-NOTICE: Portions of this project are tightly based off of OSVR-Vive-Libre
- which is under a forced-source license.  I have rewritten as much as I can
- to avoid that, however, I may have made some mistakes.  Magic numbers
- have not been modified as they cannot and (thankfully) are exempt from 
- copyright law.
-
 NOTICE: Based off of https://github.com/collabora/OSVR-Vive-Libre
  Originally Copyright 2016 Philipp Zabel
  Originally Copyright 2016 Lubosz Sarnecki <lubosz.sarnecki@collabora.co.uk>
  Originally Copyright (C) 2013 Fredrik Hultin
  Originally Copyright (C) 2013 Jakob Bornecrantz
 
-All other code is licensed under the MIT/x11 License.  You may re-license the code under the GPL or LGPL licenses.
+All code is licensed under the MIT/x11 License.  You may re-license the code under the GPL or LGPL licenses.
 
 MIT License
 


### PR DESCRIPTION
Background:
The relevant code in OSVR-Vive-Libre should have been largely migrated to https://github.com/lubosz/OpenHMD/tree/lighthouse/src/drv_htc_vive by now. Currently it still has LGPLv3 headers but I believe the intention of the current development is to get it into OpenHMD under OpenHMD's permissive license.

Unfortunately libsurvive does not clarify which code exactly this paragraph applies to and it might even be hard to find out which parts it still applies to after a long time with many changes.
In effect, potential users who require a library under a permissive license might be hesitant to use libsurvive or code from libsurvive (ironically some concerns come from OpenHMD).

Before this pull request is merged it would be great if the authors of the OSVR-Vive-Libre code can comment and give their explicit permission to remove this paragraph and distribute whatever fragments of their code remains in libsurvive under the MIT/x11 license.
I believe this would be mainly @lubosz