### PR TITLE
Tracker 2018 usb

### DIFF
--- a/redist/json_helpers.c
+++ b/redist/json_helpers.c
@@ -213,7 +213,7 @@ void json_load_file(const char* path) {
 	free(JSON_STRING);
 }
 
-int parse_float_array_in_place(char *str, jsmntok_t *token, FLT *f, uint8_t count) {
+int parse_float_array_in_place(char *str, const jsmntok_t *token, FLT *f, uint8_t count) {
 	for (int i = 0; i < count; ++i) {
 		char* end = str + token->end;
 		char* s = str+token->start;
@@ -233,7 +233,7 @@ int parse_float_array_in_place(char *str, jsmntok_t *token, FLT *f, uint8_t coun
 
 	return count;
 }
-int parse_float_array(char *str, jsmntok_t *token, FLT **f, uint8_t count) {
+int parse_float_array(char *str, const jsmntok_t *token, FLT **f, uint8_t count) {
 	uint16_t i = 0;
 
 	if (count == 0)
@@ -252,7 +252,7 @@ int parse_float_array(char *str, jsmntok_t *token, FLT **f, uint8_t count) {
 	return count;
 }
 
-int parse_int_array_in_place(char *str, jsmntok_t *token, int *f, uint8_t count) {
+int parse_int_array_in_place(char *str, const jsmntok_t *token, int *f, uint8_t count) {
 	for (int i = 0; i < count; ++i) {
 		char *end = str + token->end;
 		char *s = str + token->start;
@@ -267,7 +267,7 @@ int parse_int_array_in_place(char *str, jsmntok_t *token, int *f, uint8_t count)
 
 	return count;
 }
-int parse_int_array(char *str, jsmntok_t *token, int **f, uint8_t count) {
+int parse_int_array(char *str, const jsmntok_t *token, int **f, uint8_t count) {
 	uint16_t i = 0;
 
 	if (count == 0)

--- a/redist/json_helpers.h
+++ b/redist/json_helpers.h
@@ -14,11 +14,11 @@ void json_write_uint32(FILE* f, const char* tag, uint32_t v);
 void json_write_float(FILE* f, const char* tag, float v);
 void json_write_str(FILE* f, const char* tag, const char* v);
 
-int parse_float_array_in_place(char *str, jsmntok_t *token, FLT *values, uint8_t count);
-int parse_float_array(char* str, jsmntok_t* token, FLT** values, uint8_t count);
+int parse_float_array_in_place(char *str, const jsmntok_t *token, FLT *values, uint8_t count);
+int parse_float_array(char *str, const jsmntok_t *token, FLT **values, uint8_t count);
 
-int parse_int_array_in_place(char *str, jsmntok_t *token, int *values, uint8_t count);
-int parse_int_array(char *str, jsmntok_t *token, int **values, uint8_t count);
+int parse_int_array_in_place(char *str, const jsmntok_t *token, int *values, uint8_t count);
+int parse_int_array(char *str, const jsmntok_t *token, int **values, uint8_t count);
 
 void json_load_file(const char* path);
 extern void (*json_begin_object)(char* tag);

--- a/src/test_cases/watchman.c
+++ b/src/test_cases/watchman.c
@@ -18,7 +18,7 @@ TEST(ViveDriver, TestWatchmanParsing) {
 	}
 
 	{
-		uint8_t readdata[] = {, 0x6f, 0xfd, 0x83, 0xff};
+		uint8_t readdata[] = {0x00, 0x6f, 0xfd, 0x83, 0xff};
 
 		LightcapElement les[10];
 		int cnt = parse_watchman_lightcap(0, "WW0", 224, 3761897504, readdata, sizeof(readdata), les, 10);


### PR DESCRIPTION
Turns out I had a nasty bug in my code and went on a wild goose chase. The lightcap data is as we expect it to be, only at a different endpoint. This commit adds non-HIDAPI access to a 2018 Tracker (called a TRACKER1 in the code) and pulls button, IMU and light data from it over USB. It also reads the new "head" element from the JSON configuration file.