### PR TITLE
[feature] Access to device serial numbers from the API/so (not lighthouses)

### DIFF
--- a/include/libsurvive/survive.h
+++ b/include/libsurvive/survive.h
@@ -74,6 +74,7 @@ struct SurviveObject {
 
 	char codename[4];   // 3 letters, null-terminated.  Currently HMD, WM0, WM1.
 	char drivername[8]; // 8 letters for driver.  Currently "HTC"
+	char serial_number[16]; // 13 letters device serial number
 	void *driver;
 	int32_t buttonmask;
 	int16_t axis1;

--- a/include/libsurvive/survive_api.h
+++ b/include/libsurvive/survive_api.h
@@ -58,6 +58,11 @@ SURVIVE_EXPORT survive_timecode survive_simple_object_get_latest_pose(const Surv
  */
 SURVIVE_EXPORT const char *survive_simple_object_name(const SurviveSimpleObject *sao);
 
+/**
+ * Gets the null terminated serial number of the object.
+ */
+SURVIVE_EXPORT const char *survive_simple_serial_number(const SurviveSimpleObject *sao);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/driver_vive.c
+++ b/src/driver_vive.c
@@ -529,6 +529,8 @@ int survive_usb_init(SurviveViveData *sv) {
 
 	bool has_hmd_mainboard = false;
 
+	char* serial_numbers[MAX_USB_DEVS];
+
 	for (const struct DeviceInfo *info = KnownDeviceTypes; info->name; info++) {
 		if (info == 0 || strstr(blacklist, info->name)) {
 			continue;
@@ -569,6 +571,9 @@ int survive_usb_init(SurviveViveData *sv) {
 				continue;
 			}
 
+			serial_numbers[sv->udev_cnt - 1] = malloc(16*sizeof(char) );
+			wcstombs(serial_numbers[sv->udev_cnt - 1], d->serial_number, 16*sizeof(char) );
+
 			SV_INFO("Successfully enumerated %s %04x:%04x", info->name, idVendor, idProduct);
 		}
 	}
@@ -588,6 +593,7 @@ int survive_usb_init(SurviveViveData *sv) {
 			*cnt = *cnt + 1;
 
 			SurviveObject *so = survive_create_device(ctx, "HTC", sv, codename, 0);
+			strcpy(so->serial_number, serial_numbers[ctx->objs_ct]);
 			survive_add_object(ctx, so);
 			usbInfo->so = so;
 

--- a/src/survive_api.c
+++ b/src/survive_api.c
@@ -25,6 +25,7 @@ struct SurviveSimpleObject {
 	} data;
 
 	char name[32];
+	char serial_number[16];
 	bool has_update;
 };
 
@@ -121,6 +122,7 @@ struct SurviveSimpleContext *survive_simple_init(int argc, char *const *argv) {
 		obj->actx = actx;
 		obj->data.so->user_ptr = (void*)i;
 		snprintf(obj->name, 32, "%s", obj->data.so->codename);
+		snprintf(obj->serial_number, 16, "%s", obj->data.so->serial_number);
 	}
 
 	survive_install_pose_fn(ctx, pose_fn);
@@ -222,3 +224,4 @@ uint32_t survive_simple_object_get_latest_pose(const struct SurviveSimpleObject 
 }
 
 const char *survive_simple_object_name(const SurviveSimpleObject *sao) { return sao->name; }
+const char *survive_simple_serial_number(const SurviveSimpleObject *sao) { return sao->serial_number; }


### PR DESCRIPTION
I have added the ability to get the device serial numbers from the API/SurviveObject. It currently has one flaw that I haven't figured out though, it currently returns the "device_serial_number" for the HMD and "mb_serial_number" for others (e.g. controllers). I am currently using this serial number as a unique identifier for the devices, and I would like for this to work similarly to the Prop_SerialNumber_String in OpenVR (e.g. LHR-XXXXXXXX, and with lighthouses).