### PR TITLE
fix IO_off64_t datatype after glibc update

### DIFF
--- a/src/driver_usbmon.c
+++ b/src/driver_usbmon.c
@@ -507,7 +507,7 @@ static int gzip_cookie_close(void *cookie) { return gzclose((gzFile)cookie); }
 
 static ssize_t gzip_cookie_read(void *cookie, char *buf, size_t nbytes) { return gzread((gzFile)cookie, buf, nbytes); }
 
-int gzip_cookie_seek(void *cookie, _IO_off64_t *pos, int __w) { return gzseek((gzFile)cookie, *pos, __w); }
+int gzip_cookie_seek(void *cookie, off64_t *pos, int __w) { return gzseek((gzFile)cookie, *pos, __w); }
 
 cookie_io_functions_t gzip_cookie = {
 	.close = gzip_cookie_close, .write = gzip_cookie_write, .read = gzip_cookie_read, .seek = gzip_cookie_seek};


### PR DESCRIPTION
```
libsurvive/src/driver_usbmon.c:510:36: error: unknown type name '_IO_off64_t'; did you mean '__off64_t'?
  510 | int gzip_cookie_seek(void *cookie, _IO_off64_t *pos, int __w) { return gzseek((gzFile)cookie, *pos, __w); }
      |                                    ^~~~~~~~~~~
      |                                    __off64_t
```

https://sourceware.org/git/?p=glibc.git;a=commit;h=9964a14579e5eef925aaa82facc4980f627802fe