### PR TITLE
make valgrind happy by not using strlen()

### DIFF
--- a/src/driver_vive.c
+++ b/src/driver_vive.c
@@ -2824,7 +2824,7 @@ static int LoadConfig(SurviveViveData *sv, struct SurviveUSBInfo *usbInfo, int i
 		char raw_fname[100];
 		sprintf(raw_fname, "%s_config.json", so->codename);
 		FILE *f = fopen(raw_fname, "w");
-		fwrite(ct0conf, strlen(ct0conf), 1, f);
+		fwrite(ct0conf, len, 1, f);
 		fclose(f);
 	}
 


### PR DESCRIPTION
This is the only complaint during runtime I saw in valgrind (see commit description). Not sure if there's a reason strlen() instead of the len from zlib deflate was used, but for me it works.