### PR TITLE
api: update device type once available

### DIFF
--- a/include/libsurvive/survive_api.h
+++ b/include/libsurvive/survive_api.h
@@ -12,6 +12,7 @@ struct SurviveSimpleContext;
 typedef struct SurviveSimpleContext SurviveSimpleContext;
 
 enum SurviveSimpleObject_type {
+	SurviveSimpleObject_UNKNOWN,
 	SurviveSimpleObject_LIGHTHOUSE,
 	SurviveSimpleObject_HMD,
 	SurviveSimpleObject_OBJECT,


### PR DESCRIPTION
The SurviveSimpleObject_type was never set to HMD, because to figure out
if a device is an HMD, the config parsing needed to be triggered from
the usb polling.

Now the type will be kept at unknown until it can be updated to an
actual type. The application will have to wait for the type to be
available before knowing which device is which.